### PR TITLE
allow bundling/minifying in otherwise empty assets

### DIFF
--- a/classes/sprockets/file.php
+++ b/classes/sprockets/file.php
@@ -55,9 +55,9 @@ class Sprockets_File
 	public function save_file($file_path, $source)
 	{
 		$path = trim($file_path);
+		$successful = (file_put_contents($path, $source) !== false);
 
-		if ( ! $save = file_put_contents($path, $source) )
-		{
+		if ( !$successful ) {
 			throw new SprocketsFileException("$file_path could not be saved. Do you have write permissions?", 1);
 		}
 	}


### PR DESCRIPTION
This pull request addresses an issue when trying to bundle/minify a file that only contain Sprocket-directives.

In current master, file_put_contents(...) report a size of 0 after minifying a file with only comments (as they are removed). As 0 is a falsy value, the check !0 is true and Sprocket throws an exception.

This commit solves the issue by specifically checking if the returned value is false.
