### PR TITLE
Change Caching Method to Use md5 of File Contents Instead of Modification Times

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ setting `force_minify` to `true` in the Sprockets config file.
 # Smart Caching #
 
 Fuel Sprockets is smart about caching. The final compiled source for each file that is
-included in your bundles in cached inside `fuel/app/cache/sprockets`. The Last Modified
-timestamp and minification flag (`.min`) are appended to the filename so that we can
+included in your bundles in cached inside `fuel/app/cache/sprockets`. An md5 string of the 
+file contents and minification flag (`.min`) are appended to the filename so that we can
 compare when your asset file has changed and whether the generated file is up-to-date.
 
 # Running Tests #

--- a/classes/sprockets/file.php
+++ b/classes/sprockets/file.php
@@ -142,6 +142,21 @@ class Sprockets_File
 
 	/**
 	 * @access 	public
+	 * @param 	string $file_path
+	 * @return 	string md5 of the file contents
+	 */
+	public function get_file_md5($file_path)
+	{
+		$path = trim($file_path);
+
+		if ( ! is_file($path) ) {
+			throw new SprocketsFileNotFoundException("Could not get File MD5 for $path", 1);
+		}
+		return md5_file($path);
+	}
+
+	/**
+	 * @access 	public
 	 * @param 	string filepath
 	 * @return 	int last modified time in UTC
 	 */


### PR DESCRIPTION
## Changes
- Checks the md5 of the file contents instead of the file modification times when checking to see if a file should be reprocessed.

## About
- This brings it more in line with the rails asset pipeline: http://guides.rubyonrails.org/asset_pipeline.html#what-is-fingerprinting-and-why-should-i-care-questionmark
- Also fixes an issue in a multiple server environment. When deploying to multiple servers the file modification times are slightly different. This causes the md5 of the files to be slightly different on **Server A** and and **Server B**. When load balancing between the servers sometimes the first request will be routed to **Server A**, then the second request for the css file we be routed to **Server B** which will 404. If we use an md5 of the file contents this will no longer be an issue because the hash will be exactly the same.

